### PR TITLE
docs: use `main` branch for source links (fixes #11)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@
 
 [//]: # (exclude 'Installation' section)
 --8<-- "README.md:23:52"
+
 --8<-- "README.md:68"
 
 [contributing]: /contributing

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ copyright: Copyright &copy; 2023 Jonathan Hiles
 # Repository
 repo_name: axieum/django-user-trace
 repo_url: https://github.com/axieum/django-user-trace
+edit_uri: blob/main/docs/
 
 # Theme
 theme:


### PR DESCRIPTION
Fixes #11 